### PR TITLE
Mention PBox2D -> Box2DProcessing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A Processing library wrapping JBox2D (http://www.jbox2d.org/).
 
 Download library: http://www.shiffman.net/p5/libraries/box2d_processing/box2d_processing.zip
 
-Tutorial and further examples for this library are available in The Nature of Code book: http://natureofcode.com.
+Tutorial and further examples for this library are available in The Nature of Code book: http://natureofcode.com. Note that there have been some changes to the library since the book was published; in particular you'll need to replace references to the `PBox2D` class with `Box2DProcessing`.


### PR DESCRIPTION
Hi Daniel! Thanks so much for your work on Box2D-for-Processing, and for making the _Nature of Code_ book freely available (I think I actually bought a copy when it came out, but it's been a long time...). I just tried to set up a project based on the book and tripped over the PBox2D class being unavailable, and found [in the Processing forum](https://forum.processing.org/two/discussion/12672/how-to-use-box2d-in-processing.html) that it'd been replaced by Box2DProcessing.

PR just makes brief mention of that in the README. It may be that there are other changes that have to be taken into account; if I stumble across more I'll try to create PRs for them as I have time.

Thanks again!